### PR TITLE
Faster GitHub Actions builds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           repository: raspberrypi/pico-sdk
           path: pico-sdk
-          submodules: recursive
+          submodules: true
       - name: Install Pico SDK dependencies
         run: sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
       - name: Build firmware


### PR DESCRIPTION
Checking out submodules recursively is not necessary for the Pico SDK to work. TinyUSB has many submodules for other targets but none are required for RP2040.